### PR TITLE
docs(reading): add Acemoglu economics of AI article

### DIFF
--- a/reading/reading.md
+++ b/reading/reading.md
@@ -43,3 +43,7 @@ Such a great text about how memory, pointers and stacks work in Go.
 Originally questioned by Socrates and written by Plato, this myth is about the invention of writing and how it would affect the memory of the people.
 
 Theuth, a smarth guy who invented some intresting things, show his inventions to Thamus,saying that his inventions will make the people wiser and improve their memory to spread stories and knowledge. Thamus was against the invention, because for him, the most important thing in that era, was the dialectic, and if people start to write things, they will forget how to convince others with their own words.
+
+## [Daron Acemoglu: What do we know about the economics of AI?](https://economics.mit.edu/news/daron-acemoglu-what-do-we-know-about-economics-ai)
+
+Acemoglu argues that despite the massive investment, AI's economic impact will likely be modest (around 0.5% productivity gains over the next decade), and that the technology should be directed toward enhancing worker productivity rather than replacing jobs.


### PR DESCRIPTION
Adds Daron Acemoglu's MIT piece *What do we know about the economics of AI?* to the read-articles list in `reading/reading.md`, with a one-line summary of its main argument.